### PR TITLE
Adding ability to execute stryker only for the changes and in parallel for faster execution

### DIFF
--- a/FunctionalProjectTestProjectMap.json
+++ b/FunctionalProjectTestProjectMap.json
@@ -1,0 +1,40 @@
+{
+	"projectmapper": [
+		{
+			"csProjPath":"ELN.Search\\BPT.Search.Api\\BPT.Search.Api.csproj",
+			"testPath":"ELN.Search\\BPT.Search.Api.Tests\\",
+			"referenceProjectPath": []
+		},
+		{
+			"csProjPath":"ELN.Search\\ELN.Search.Api\\ELN.Search.Api.csproj",
+			"testPath":"ELN.Search\\ELN.Search.Api.Tests\\",
+			"referenceProjectPath": [
+			"ELN.Search\\ELN.Search.Infrastructure\\ELN.Search.Infrastructure.csproj"
+			]
+		},
+		{
+			"csProjPath": "ELN.Search\\ELN.SearchIndexer.Api\\ELN.SearchIndexer.Api.csproj",
+			"testPath": "ELN.Search\\ELN.Experiment.SearchIndexer.Tests\\",
+			"referenceProjectPath": [
+			"ELN.Search\\ELN.SearchIndexer.Infrastructure\\ELN.SearchIndexer.Infrastructure.csproj",
+			"ELN.Search\\ELN.Search.Common\\ELN.Search.Common.csproj"
+			]
+		},
+		{
+			"csProjPath": "ELN.Search\\ELN.Preparation.SearchIndexer.API\\ELN.Preparation.SearchIndexer.API.csproj",
+			"testPath": "ELN.Search\\ELN.Preparation.SearchIndexer.Test\\",
+			"referenceProjectPath": [
+			"ELN.Search\\ELN.Preparation.SearchIndexer.Infrastructure\\ELN.Preparation.SearchIndexer.Infrastructure.csproj",
+			"ELN.Search\\ELN.Search.Common\\ELN.Search.Common.csproj"
+			]
+		},
+		{
+			"csProjPath": "ELN.Search\\ELN.Recipe.SearchIndexer.API\\ELN.Recipe.SearchIndexer.API.csproj",
+			"testPath": "ELN.Search\\ELN.Recipe.SearchIndexer.Test\\",
+			"referenceProjectPath": [
+			"ELN.Search\\ELN.Recipe.SearchIndexer.Infrastructure\\ELN.Recipe.SearchIndexer.Infrastructure.csproj",
+			"ELN.Search\\ELN.Search.Common\\ELN.Search.Common.csproj"
+			]
+		}
+	]
+}

--- a/Get-ChangeFileset.ps1
+++ b/Get-ChangeFileset.ps1
@@ -1,0 +1,260 @@
+#README.TXT
+# Get-ChangeFileset.ps1 should be available in the same path as Run-Stryker.ps1
+# Refer to Run-Stryker.ps1 README for the script usage and how it works
+[CmdletBinding()]
+param ([Parameter()]
+	[string] $logFileName,
+    [string] $sinceCommit=""
+)
+
+if ([string]::IsNullOrEmpty($logFileName)) {
+	$fileName = "StrykerLog" + $(get-date -f yyyyMMddTHHmmssZ) +".log"
+	$logFilePath = Join-Path -Path $PSScriptRoot -childPath $fileName
+}
+$basePath = $PSScriptRoot
+$projectMapData = $null
+$mappingFileName = "FunctionalProjectTestProjectMap.json"
+$strykerDatajsonFile = "stryker.data.json"
+$strykerOutputPath = "StrykerOutput\"
+$strykerDatajson = @{
+
+    solutionPath = ""
+    jsonReportsPath = ""
+    projectsToTest = @()
+}
+
+$allowedFileType = @(".cs")
+
+function Get-ProjectMapStructureObject($csproj, $testPath) {
+	return @{
+		csProjPath = $($csproj)
+	    testPath = $($testPath)
+	}
+}
+
+
+function Get-AllChanges($commitId) {
+	$path = Get-Item $PSScriptRoot
+	$parentPath = $path.Parent
+	$cmd = "git log --oneline " + $commitId + "^..HEAD"
+	$cmdOutput = Invoke-Expression $cmd
+	$commitList = @()
+	$fileList = @()
+	foreach($s in $cmdOutput)
+	{
+		$currentCommitId = $s.split(' ')[0]
+		if($commitId.IndexOf($currentCommitId) -gt -1) {
+			continue
+		}
+		$commitList += $currentCommitId
+	}
+	foreach($s in $commitList){
+        Write-Log "Getting details for commit $s"
+		$commitcmd = "git show --oneline " + $s +" --name-status"
+		$diffcmd = "git diff --name-status"
+		$commitcmdOutput = Invoke-Expression $commitcmd
+		foreach($line in $commitcmdOutput) {
+			if ($line.IndexOf($s) -ne -1) {
+				continue;
+			}
+			else {
+				$fileInfo=@{
+						UpdateType = $line.split('')[0]
+						FilePath = $(Join-Path -Path $parentPath.FullName -childPath $line.split('')[1])
+				}
+			}
+			$fileList += New-Object PSObject -Property $fileInfo
+		}
+		$diffcmdOutput = Invoke-Expression $diffcmd
+		foreach($line in $diffcmdOutput) {
+			if ($line.IndexOf($s) -ne -1) {
+				continue;
+			}
+			else {
+				$fileInfo=@{
+						UpdateType = $line.split('')[0]
+						FilePath = $(Join-Path -Path $parentPath.FullName -childPath $line.split('')[1])
+				}
+			}
+			$fileList += New-Object PSObject -Property $fileInfo
+		}
+	}
+    Write-Log ("Total files found is " + $fileList.Count)
+    return $fileList
+}
+
+function Get-StrykerDatajson($fileList, $projectMapData) {
+	foreach($file in $fileList) {
+        if(-not (Test-Path -Path $file.FilePath)) {
+            continue
+        }
+		if($file.UpdateType -eq 'A' -or $file.UpdateType -eq 'M') {
+            $fInfo = Get-Item $file.FilePath
+		    $extn = [IO.Path]::GetExtension($fInfo)
+		    if ($allowedFileType -contains $extn) {
+			    $projPath = Get-ProjectFromFilePath $fInfo.Directory.FullName
+			    if ([string]::IsNullOrEmpty($projPath)) {
+				    Write-Log "Project file not available for $($file.FilePath)"
+			    }
+			    $projTestPath = Get-TestProjectForFunctionalProject $projPath
+                $projFunctionalPath = Get-FunctionalProjectForReferenceProject $projPath
+			    if (-not [string]::IsNullOrEmpty($projTestPath)) {
+			        $projmapinfo = Get-ProjectMapStructureObject $projFunctionalPath $projTestPath
+                    $result = Check-ProjectAlreadyAdded $projmapinfo
+                    if(-not $result) {
+			            $strykerDatajson.projectsToTest += New-Object PSObject -Property $projmapinfo
+                    }
+                }
+                continue
+		    }
+		    else {
+			    Write-Log "$($file.FilePath) is not configured for stryker execution"
+			    continue
+		    }
+        }
+	}
+}
+
+function Check-ProjectAlreadyAdded($projmapinfo) {
+    
+    if($strykerDatajson.projectsToTest.Count -eq 0) {
+        return $false
+    }
+    foreach($info in $strykerDatajson.projectsToTest) {
+        if($projmapinfo.csProjPath -eq $info.csProjPath){
+            return $true
+        }
+    }
+    return $false
+}
+
+function Get-FunctionalProjectForReferenceProject($projPath) {
+    Get-ProjectPath $projPath $false
+}
+
+function Get-TestProjectForFunctionalProject($projPath) {
+    Get-ProjectPath $projPath $true
+}
+
+function Get-AllProjectStrykerJsonData() {
+	
+	$path = Get-Item $PSScriptRoot
+	$parentPath = $path.Parent.FullName
+    foreach ($project in $projectMapData.projectmapper){
+		$projFullPath = Join-Path -Path $parentPath -childPath $project.csProjPath
+		$testProjFullPath = Join-Path -Path $parentPath -childPath $project.testPath
+		$projmapinfo = Get-ProjectMapStructureObject $projFullPath $testProjFullPath
+		$result = Check-ProjectAlreadyAdded $projmapinfo
+		if(-not $result) {
+			$strykerDatajson.projectsToTest += New-Object PSObject -Property $projmapinfo
+		}
+	}
+}
+
+function Get-ProjectPath($projPath, $isTestProject) {
+	$isTestProjAvailable = $false
+	$path = Get-Item $PSScriptRoot
+	$parentPath = $path.Parent.FullName
+	foreach ($project in $projectMapData.projectmapper){
+		$projFullPath = Join-Path -Path $parentPath -childPath $project.csProjPath
+		$testProjFullPath = Join-Path -Path $parentPath -childPath $project.testPath
+		if($projFullPath -eq $projPath) {
+			if($isTestProject -eq $true) {
+                return $testProjFullPath
+            }
+            else {
+                return $projFullPath
+            }
+		}
+        foreach($refProj in $project.referenceProjectPath){
+			$projFullPath = Join-Path -Path $parentPath -childPath $project.csProjPath
+			$testProjFullPath = Join-Path -Path $parentPath -childPath $project.testPath
+			$refProjFullPath = Join-Path -Path $parentPath -childPath $refProj
+            if($refProjFullPath -eq $projPath) {
+			    if($isTestProject -eq $true) {
+                    return $testProjFullPath
+                }
+                else {
+                    return $projFullPath
+                }
+		    }
+        }
+	}
+	if (!$isTestProjAvailable){
+		Write-Log "No test project mapped for $projPath. Hence stryker will not be executed for this project"
+	}
+	return
+}
+
+function Load-TestProjectForFunctionalProject() {
+	$mappingFile = Join-Path -path $basePath -childPath $mappingFileName
+	if (Test-Path $mappingFile) {
+		$projectMapData = (Get-Content $mappingFile | Out-String | ConvertFrom-Json)
+	}
+	else {
+		Write-Log "$mappingFileName not available in root path $basePath"
+		throw
+	}
+    return $projectMapData
+}
+
+function Get-ProjectFromFilePath($path) {
+	$proj = Get-ChildItem -Path $path  -Filter "*.csproj"
+	if ($proj.Count -gt 1){
+		return
+	}
+	elseif($proj.Count -eq 1) {
+		return $proj.FullName
+	}
+	elseif($proj.Count -eq 0){
+		$curr = Get-Item $path
+		if($curr.Parent -eq $basePath) {
+			return
+		}
+		else {
+			Get-ProjectFromFilePath $curr.Parent
+		}
+	}
+	return
+}
+
+function Save-MetadataToStrykerDatajson(){
+	$strykerDatajson.solutionPath = Get-solutionPath
+	$strykerDatajson.jsonReportsPath = Join-path -path $basePath -childPath $strykerOutputPath
+	$strykerjsonFilePath = Join-Path -Path $basePath -childPath $strykerDatajsonFile
+	if ((Test-Path $strykerDatajsonFile -PathType Leaf)) {
+		Remove-Item -Path $strykerjsonFilePath -Force
+	}
+    $strykerDatajson | ConvertTo-Json | Set-Content -Path $strykerjsonFilePath
+}
+
+function Get-solutionPath() {
+	$sol = Get-ChildItem -Path $basePath  -Filter "*.sln"
+	if ($sol.Count -gt 1){
+		Write-Log "More than one solution file available in root path $basePath"
+		throw
+	}
+	elseif($sol.Count -eq 1) {
+		return ($sol.FullName )
+	}
+	else {
+		Write-Log "No solution is available in root path $basePath"
+		throw
+	}
+}
+
+function Write-Log($text) {
+	Write-Host $text
+	$text | Out-File -FilePath $logFilePath -Append
+}
+
+
+$projectMapData = Load-TestProjectForFunctionalProject
+if ([string]::IsNullOrEmpty($sinceCommit)) {
+	Get-AllProjectStrykerJsonData
+}
+else {
+	$fileList = Get-AllChanges $sinceCommit
+	Get-StrykerDatajson $fileList $projectMapData
+}
+Save-MetadataToStrykerDatajson

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Stryker.MultipleProjectRunner
-Runs Stryker for multiple .NET Core projects and aggregates the results, based on [this GitHub conversation](https://github.com/stryker-mutator/stryker-net/issues/740). 
+Runs Stryker for multiple .NET Core projects and aggregates the results, based on [this GitHub conversation](https://github.com/stryker-mutator/stryker-net/issues/740). The script gets a commit id and gather all the changes done since that commit and creates a project & unit test mapping file which is used to execute stryker in parallel fashion
+The script needs a json file (FunctionalProjectTestProjectMap.json) containing the mapping to functional project and its respective test project. The other project references used by the main functional project can be included in the referenceProjectPath.
 
-TL;DR: Stryker cannot run for an entire solution with multiple test projects (YET), so we need to help it a little and run each project by itself and then join the results.
+TL;DR: Stryker is capable of running only for changes using --Since commit flag but consumes lot of time in getting the list of mutants to be executed. Hence we create the functional project & test project only for the changes in the commit and execute stryker in parallel.
 
 ### Note
-This is a first draft and could use some more error handling 😄.
+Have added logs for every script but still error handling can be improved.
 
 
 ## Requirements
@@ -14,33 +15,43 @@ This is a first draft and could use some more error handling 😄.
 * Update the datafile with your files. See `DATAFILE` below.
 
 ## Running this script
-Just call the script. It creates an Output directory from your starting path and will save all output files there
+Just call the script with commitId from which you want stryker to execute. If no commitid is provided, then stryker gets executed for all available project in FunctionalProjectTestProjectMap.json. It creates an Output directory from your starting path and will save all output files there
 
 Files needed:
-* Run Stryker.ps1
-* Stryker.data.json
+* Run-Stryker.ps1
+* Get-ChangeFileset.ps1
+* Run-StrykerForOneAssembly.ps1
+* stryker-config.json
+* FunctionalProjectTestProjectMap.json
 * StrykerReportEmpty.html
 
 ## What will happen?
-The data file will be read from disk. Each project in the "projectsToTest" setting will be send to a Stryker run. The last generated json file from that run will be copied with a datetime in the filename to the `jsonReportsPath` path.
-After all runs have been completed, the json files in the Output directory will be joined and copied into the empty report html file by matter of string replacement. A JavaScript file from the Stryker CDN will be added to the html report as well.
+ parameter commit - commit id from which the changes will be considered for stryker execution. The changes in the given commit is excluded
+ StrykerReportEmpty.html should be availabe in the same script root path. This file is used as template for html stryker report generation
+ Get-ChangeFileset.ps1 should be available in the same script root path
+ Run-StrykerForOneAssembly.ps1 should be available in the same script root path
+ FunctionalProjectTestProjectMap.json should contain mapping of functional project to test project. The reference project to functional project can be included in "referenceProjectPath"
+ Get-ChangeFileset.ps1 file creates stryker.data.json in the same script root path.
+ Run-StrykerForOneAssembly.ps1 will be executed for every functional and test project combination given in stryker.data.json
+ Logs for Run-Stryker.ps1 & Get-ChangeFileset.ps1 script will be created in rootpath\strykeroutput folder and filename would be prefixed with "StrykerLog" 	   followed by timestamp with format "yyyyMMddTHHmmssZ"
+ Logs for Run-StrykerForOneAssembly.ps1 will be created in the test project path under the folder "StrykerOutput" and filename would be prefixed with "StrykerLog" followed by timestamp with format "yyyyMMddTHHmmssZ"
+ logs for stryker execution will be stored under the folder "StrykerOutput" and under the timestamp folder
+ stryker config file "stryker-config.json" is stored in script root path
+ StrykerReportEmpty.html should be availabe
+ gitignore files will be created in all folder created by the script
 
-The html report will be stand-alone after the run.
-
-
-## DATAFILE
+## DATAFILE (FunctionalProjectTestProjectMap.json)
 In the datafile the following properties should be set:
 
 |Property|Example|Description|
-|---|---|---|
-|solutionPath|`D:\Source\SolutionFolder\MySolution.sln`|Full file path to the Visual Studio Solution file that the Projects in `projectsToTest` are a part of|
-|jsonReportsPath|`D:\Source\SolutionFolder\Stryker.Output\`|Output folder|
-|projectsToTest|see below|Array of projects to run|
 
-### ProjectsToTest array
-The projectsToTest property is an array of items with these properties:
+|projectmapper|see below|Array of projects to run|
+
+### projectmapper array
+The projectmapper property is an array of items with these properties:
 
 |Property|Example|Description|
 |---|---|---|
 |csProjPath|`D:\Source\SolutionFolder\src\ProjectFolder\project.csproj`|FilePath of the project file to mutate|
 |testPath|`D:\Source\SolutionFolder\test\ProjectFolder-Tests\`|FilePath of the test folder to run the tests in|
+|referenceProjectPath| array of project path which also share the same unit test project

--- a/README.md
+++ b/README.md
@@ -26,25 +26,25 @@ Files needed:
 * StrykerReportEmpty.html
 
 ## What will happen?
- parameter commit - commit id from which the changes will be considered for stryker execution. The changes in the given commit is excluded
- StrykerReportEmpty.html should be availabe in the same script root path. This file is used as template for html stryker report generation
- Get-ChangeFileset.ps1 should be available in the same script root path
- Run-StrykerForOneAssembly.ps1 should be available in the same script root path
- FunctionalProjectTestProjectMap.json should contain mapping of functional project to test project. The reference project to functional project can be included in "referenceProjectPath"
- Get-ChangeFileset.ps1 file creates stryker.data.json in the same script root path.
- Run-StrykerForOneAssembly.ps1 will be executed for every functional and test project combination given in stryker.data.json
- Logs for Run-Stryker.ps1 & Get-ChangeFileset.ps1 script will be created in rootpath\strykeroutput folder and filename would be prefixed with "StrykerLog" 	   followed by timestamp with format "yyyyMMddTHHmmssZ"
- Logs for Run-StrykerForOneAssembly.ps1 will be created in the test project path under the folder "StrykerOutput" and filename would be prefixed with "StrykerLog" followed by timestamp with format "yyyyMMddTHHmmssZ"
- logs for stryker execution will be stored under the folder "StrykerOutput" and under the timestamp folder
- stryker config file "stryker-config.json" is stored in script root path
- StrykerReportEmpty.html should be availabe
- gitignore files will be created in all folder created by the script
+ * parameter commit - commit id from which the changes will be considered for stryker execution. The changes in the given commit is excluded
+ * StrykerReportEmpty.html should be availabe in the same script root path. This file is used as template for html stryker report generation
+ * Get-ChangeFileset.ps1 should be available in the same script root path
+ * Run-StrykerForOneAssembly.ps1 should be available in the same script root path
+ * FunctionalProjectTestProjectMap.json should contain mapping of functional project to test project. The reference project to functional project can be included in "referenceProjectPath"
+ * Get-ChangeFileset.ps1 file creates stryker.data.json in the same script root path.
+ * Run-StrykerForOneAssembly.ps1 will be executed for every functional and test project combination given in stryker.data.json
+ * Logs for Run-Stryker.ps1 & Get-ChangeFileset.ps1 script will be created in rootpath\strykeroutput folder and filename would be prefixed with "StrykerLog" 	   followed by timestamp with format "yyyyMMddTHHmmssZ"
+ * Logs for Run-StrykerForOneAssembly.ps1 will be created in the test project path under the folder "StrykerOutput" and filename would be prefixed with "StrykerLog" followed by timestamp with format "yyyyMMddTHHmmssZ"
+ * Logs for stryker execution will be stored under the folder "StrykerOutput" and under the timestamp folder
+ * stryker config file "stryker-config.json" is stored in script root path
+ * StrykerReportEmpty.html should be availabe
+ * gitignore files will be created in all folder created by the script
 
 ## DATAFILE (FunctionalProjectTestProjectMap.json)
 In the datafile the following properties should be set:
 
 |Property|Example|Description|
-
+|---|---|---|
 |projectmapper|see below|Array of projects to run|
 
 ### projectmapper array
@@ -54,4 +54,4 @@ The projectmapper property is an array of items with these properties:
 |---|---|---|
 |csProjPath|`D:\Source\SolutionFolder\src\ProjectFolder\project.csproj`|FilePath of the project file to mutate|
 |testPath|`D:\Source\SolutionFolder\test\ProjectFolder-Tests\`|FilePath of the test folder to run the tests in|
-|referenceProjectPath| array of project path which also share the same unit test project
+|referenceProjectPath|`[D:\Source\SolutionFolder\src\ProjectFolder1\project1.csproj, D:\Source\SolutionFolder\src\ProjectFolder2\project2.csproj]`| array of project path which also share the same unit test project

--- a/Run-Stryker.ps1
+++ b/Run-Stryker.ps1
@@ -1,0 +1,309 @@
+# README .TXT
+# parameter commit - commit id from which the changes will be considered for stryker execution. The changes in the given commit is excluded
+# StrykerReportEmpty.html should be availabe in the same script root path. This file is used as template for html stryker report generation
+# Get-ChangeFileset.ps1 should be available in the same script root path
+# Run-StrykerForOneAssembly.ps1 should be available in the same script root path
+# FunctionalProjectTestProjectMap.json should contain mapping of functional project to test project. The reference project to functional project can be included in "referenceProjectPath"
+# Get-ChangeFileset.ps1 file creates stryker.data.json in the same script root path.
+# Run-StrykerForOneAssembly.ps1 will be executed for every functional and test project combination given in stryker.data.json
+# Logs for this & Get-ChangeFileset.ps1 script will be created in rootpath\strykeroutput folder and filename would be prefixed with "StrykerLog" 	   followed by timestamp with format "yyyyMMddTHHmmssZ"
+# Logs for Run-StrykerForOneAssembly.ps1 will be created in the test project path under the folder "StrykerOutput" and filename would be prefixed with "StrykerLog" followed by timestamp with format "yyyyMMddTHHmmssZ"
+# logs for stryker execution will be stored under the folder "StrykerOutput" and under the timestamp folder
+# stryker config file "stryker-config.json" is stored in script root path
+# StrykerReportEmpty.html should be availabe
+# gitignore files will be created in all folder created by the script
+
+[CmdletBinding()]
+param ([Parameter()] 
+	[string] $commit=""
+)
+
+
+function JoinStykerJsonFile ($additionalFile, $joinedFileName) {
+    Join-FilesSection $additionalFile $joinedFileName
+	Join-TestFilesSection $additionalFile $joinedFileName
+}
+
+function Join-FilesSection($additionalFile, $joinedFile) {
+	
+	$joinedFileContent = (Get-Content $joinedFile | Out-String) 
+	$additionalFileContent = (Get-Content $additionalFile | Out-String)
+	
+	$offset = 2  # for removing trailing comma from content 
+	$startStringToSearchFor = '"files":{'
+	$startStringToSearchForLength = $startStringToSearchFor.Length
+
+	$endStringToSearchFor = '"testFiles":{'
+	$endStringToSearchForLength = $endStringToSearchFor.Length
+	
+	$indexofstartStringToSearchForInAdditionalFile = $additionalFileContent.IndexOf($startStringToSearchFor) 
+	$indexofendStringToSearchForInAdditionalFile = $additionalFileContent.IndexOf($endStringToSearchFor)
+	
+	$ContentFromAdditionalFile = $additionalFileContent.Substring($indexofstartStringToSearchForInAdditionalFile+$startStringToSearchForLength, $indexofendStringToSearchForInAdditionalFile - $indexofstartStringToSearchForInAdditionalFile - $startStringToSearchForLength - $offset)
+	
+	$stringToReplaceInJoinedFile = $startStringToSearchFor + $ContentFromAdditionalFile + ","
+	$updatedContent = $joinedFileContent.Replace($startStringToSearchFor, $stringToReplaceInJoinedFile)
+	
+	Set-Content -Path $joinedFile -Value $updatedContent
+}
+
+function Join-TestFilesSection($additionalFile, $joinedFile) {
+	$joinedFileContent = (Get-Content $joinedFile | Out-String) 
+	$additionalFileContent = (Get-Content $additionalFile | Out-String)
+	
+	$offset = 2 # for removing trailing '}' from content
+	$startStringToSearchFor = '"testFiles":{'
+	$startStringToSearchForLength = $startStringToSearchFor.Length
+	
+	$endStringToSearchFor = "}}"
+	$endStringToSearchForLength = $endStringToSearchFor.Length
+	
+	$indexofstartStringToSearchForInAdditionalFile = $additionalFileContent.IndexOf($startStringToSearchFor) 
+	$indexofendStringToSearchForInAdditionalFile = $additionalFileContent.LastIndexOf($endStringToSearchFor)
+	
+	$ContentFromAdditionalFile = $additionalFileContent.Substring($indexofstartStringToSearchForInAdditionalFile+$startStringToSearchForLength, $additionalFileContent.Length-($indexofstartStringToSearchForInAdditionalFile+$startStringToSearchForLength+$endStringToSearchForLength+ $offset))
+	
+	$stringToReplaceInJoinedFile = $startStringToSearchFor + $ContentFromAdditionalFile + ","
+	
+	$updatedContent = $joinedFileContent.Replace($startStringToSearchFor, $stringToReplaceInJoinedFile)
+	Set-Content -Path $joinedFile -Value $updatedContent 
+}
+
+
+function JoinJsonWithHtmlFile ($joinedJsonFileName, $reportFileName, $emptyReportFileName, $reportTitle) {
+    $report = (Get-Content $emptyReportFileName | Out-String)
+    $Json = (Get-Content $joinedJsonFileName | Out-String)
+
+    $report = $report.Replace("##REPORT_JSON##", $Json)
+    $report = $report.Replace("##REPORT_TITLE##", $reportTitle)
+    # hardcoded link to the package from the npm CDN
+    $report = $report.Replace("<script>##REPORT_JS##</script>", '<script defer src="https://www.unpkg.com/mutation-testing-elements"></script>')
+        
+    Set-Content -Path $reportFileName -Value $report
+}
+
+function JoinAllJsonFiles ($joinedFileName) {
+    $files = Get-ChildItem  -Filter "*.json" -Exclude $joinedFileName -Recurse -ErrorAction SilentlyContinue -Force
+    Write-Log "Found $($files.Count) json files to join"
+    $firstFile = $true
+    foreach ($file in $files) {
+        if ($true -eq $firstFile) {
+            # copy the first file as is
+            Copy-Item $file.FullName "$joinedFileName"
+            $firstFile = $false
+            continue
+        }
+
+        JoinStykerJsonFile $file.FullName $joinedFileName
+    }
+    Write-Log "Joined $($files.Count) files to the new json file: $joinedFileName"
+}
+
+function LoadConfigurationFile ($startDir, $configurationFile) {  
+    # try to load given file
+    $strykerDataFilePath = $configurationFile    
+    Write-Log "Searching for configuration file in this location: $strykerDataFilePath"
+    if (!(Test-Path $strykerDataFilePath -PathType Leaf)) {
+        # test for testdata first
+        $strykerDataFilePath = "$startDir\Stryker.TestData.json"
+        Write-Log "Searching for configuration file in this location: $strykerDataFilePath"
+        if (!(Test-Path $strykerDataFilePath -PathType Leaf)) {
+            # if no testdata, use the data file
+            $strykerDataFilePath = "$startDir\Stryker.data.json"            
+            Write-Log "Using configuration file in this location: $strykerDataFilePath"
+        }
+    }
+
+    Write-Log "Using configuration file at '$strykerDataFilePath'"
+    # load the data file
+    $strykerData = (Get-Content $strykerDataFilePath | Out-String | ConvertFrom-Json)
+        
+    # create a new directory for the output if needed
+    $outputPath = "$($strykerData.jsonReportsPath)"
+    New-Item $outputPath -ItemType "directory" -Force
+
+    return $strykerData
+}
+
+function DeleteDataFromPreviousRuns ($strykerData) {
+    if (!$strykerData) {
+        Write-Log "Cannot delete from unknown directory"
+        return
+    }
+    # clear the output path
+    Write-Log "Deleting previous json files from $($strykerData.jsonReportsPath)"
+    Get-ChildItem -Path "$($strykerData.jsonReportsPath)" -Include *.json -File -Recurse | ForEach-Object { $_.Delete()}
+}
+
+function MutateAllAssemblies($strykerData){
+    $counter = 1
+	$StrykerExecuteFileName = "Run-StrykerForOneAssembly.ps1"
+	$strykerFileFullPath = Join-Path -path $PSScriptRoot -childPath $StrykerExecuteFileName
+	$jobList = @()
+	$currentList = Get-Job
+	foreach($currJob in $currentList) {
+		Remove-Job -Name $currjob.Name -Force
+	}
+    foreach ($project in $strykerData.projectsToTest) {
+        $item = Get-Item -Path $project.csProjPath
+		Write-Log "Running mutation for project $($counter) of $($strykerData.projectsToTest.Length)"
+        #Run-StrykerForOneAssembly $project.csprojPath $project.testPath $strykerData.solutionPath $strykerData.jsonReportsPath
+		$jobinfo = Start-Job -FilePath $strykerFileFullPath -ArgumentList $project.csprojPath,$project.testPath,$strykerData.solutionPath,$strykerData.jsonReportsPath,$strykerConfigFile,$CommitId -Name $item.Name
+		$jobList += $jobinfo
+        $counter++
+    }
+	if($jobList.Count -eq 0) {
+		Write-Log "No project information available. Check the commit Id provided"
+		return
+	}
+	$isjobRunning = $true
+	$atleastOneJobRunning = $false
+	while ($isjobRunning -eq $true) {
+		$currentList = Get-Job
+		Write-Log ("-----------Checking the job status----------------")
+		$isjobRunning = $true
+		$atleastOneJobRunning = $false
+		foreach($currJob in $currentList) {
+			Write-Log ("The stryker execution for " + $currjob.Name + " is " + $currJob.State)
+			if($currJob.State -eq "Running" -or $currJob.State -eq "NotStarted") {
+				$isjobRunning = $true
+				$atleastOneJobRunning = $true
+			}
+			elseif ($atleastOneJobRunning -eq $false) {
+				$isjobRunning = $false
+			}
+
+		}
+		Write-Log ("-----------Next job status check after 5 seconds--")
+		Start-Sleep -Second 5
+	}
+	$currentList = Get-Job
+	foreach($currJob in $currentList) {
+		Remove-Job -Name $currjob.Name
+	}
+}
+
+function CreateReportFromAllJsonFiles ($reportDir, $startDir) {
+    # Join all the json files
+    Set-Location "$reportDir"
+    $joinedJsonFileName = "mutation-report.json"
+
+    JoinAllJsonFiles $joinedJsonFileName
+
+    # join the json with the html template for the final output
+    $reportFileName = "StrykerReport.html"
+    $emptyReportFileName = "$startDir\StrykerReportEmpty.html"
+    $reportTitle = "Stryker Mutation Testing"
+    if ((Test-Path $joinedJsonFileName -PathType Leaf)) {
+		JoinJsonWithHtmlFile $joinedJsonFileName $reportFileName $emptyReportFileName $reportTitle
+		Write-Log "Created new report file: $reportDir\$reportFileName"
+	}
+	else {
+		Write-Log "No report available. Check logs for more details"
+	}
+}
+
+function RunEverything ($startDir, $configurationFile) {
+    try {
+        $strykerData = LoadConfigurationFile $startDir $configurationFile
+
+        # check for errors
+        if( -not $?) {
+            exit;
+        }
+
+        Create-GitIgnoreFile $strykerData.jsonReportsPath
+		# clean up previous runs
+        DeleteDataFromPreviousRuns $strykerData
+
+        # mutate all projects in the data file
+        MutateAllAssemblies $strykerData
+
+        # check for errors
+        if( -not $?) {
+            exit;
+        }
+
+        CreateReportFromAllJsonFiles $strykerData.jsonReportsPath $startDir
+    }
+    finally {
+        # change back to the starting directory
+        Set-Location $startDir
+    }
+}
+
+
+function RunStryker ($startDir, $configurationFile) {
+    try {
+        $strykerData = LoadConfigurationFile $startDir $configurationFile
+
+        # check for errors
+        if( -not $?) {
+            exit;
+        }
+
+        # clean up previous runs
+        DeleteDataFromPreviousRuns $strykerData
+
+        # mutate all projects in the data file
+        MutateAllAssemblies $strykerData
+
+        # check for errors
+        if( -not $?) {
+            exit;
+        }
+    }
+    finally {
+        # change back to the starting directory
+        Set-Location $startDir
+    }
+}
+
+function Create-GitIgnoreFile($path) {
+	
+	$fullPath = Join-Path -Path $logFolderPath -childPath ".gitignore"
+	if (!(Test-Path $fullPath -PathType Leaf)) {
+		New-Item -ItemType File -Path $fullPath
+	}
+	Set-Content -Path $fullPath -Value "*"
+}
+
+function Write-Log($text) {
+	Write-Host $text
+	$text | Out-File -FilePath $logFilePath -Append
+}
+
+try {
+	
+	$stopwatch = New-Object System.Diagnostics.Stopwatch
+	$stopwatch.Start()
+	$fileName = "StrykerLog" + $(get-date -f yyyyMMddTHHmmssZ) +".log"
+	$logFolderPath = Join-Path -Path $PSScriptRoot -ChildPath "StrykerOutput"
+	if((Test-Path $logFolderPath) -eq $false) {
+		New-Item -ItemType Directory -Path $logFolderPath -Force
+	}
+	Create-GitIgnoreFile $logFolderPath
+	$logFilePath = Join-Path -Path $logFolderPath -childPath $fileName
+	$strykerConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "stryker-config.json"
+	$CommitId = $commit
+	Write-Log "Starting execution"
+	if ([string]::IsNullOrEmpty($CommitId) -eq $true) {
+		Write-Log "Commit Id not available. Stryker will be executed for all projects"
+        $CommitId = ""
+	}
+
+	$changeSetFilepath = Join-Path -Path $PSScriptRoot -childPath "Get-ChangeFileset.ps1"
+	Invoke-Expression "$changeSetFilepath $logFilePath $CommitId"
+	$startDir = Get-Location
+	Write-Log "Starting at: " $startDir
+	RunEverything $startDir $startDir -ErrorAction stop
+}
+catch {
+
+	Write-Log $Error[0]
+}
+finally {
+	$stopwatch.Stop()
+	$elapsedTime = $stopwatch.Elapsed
+	Write-Log "Execution took $elapsedTime seconds"
+}

--- a/Run-StrykerForOneAssembly.ps1
+++ b/Run-StrykerForOneAssembly.ps1
@@ -1,0 +1,79 @@
+#README.TXT
+# Run-StrykerForOneAssembly.ps1 should be available in the same path as Run-Stryker.ps1
+# Refer to Run-Stryker.ps1 README for the script usage and how it works
+
+[CmdletBinding()]
+param ([Parameter()]
+	[string] $csprojPath,
+	[string] $testPath,
+	[string] $solutionPath, 
+	[string] $outputPath,
+	[string] $strykerConfigFile,
+	[string] $commitId=""
+)
+
+$fileName = "StrykerLog" + $(get-date -f yyyyMMddTHHmmssZ) +".log"
+$logFolderPath = Join-Path -Path $testPath -ChildPath "StrykerOutput"
+if((Test-Path $logFolderPath) -eq $false) {
+	New-Item -ItemType Directory -Path $logFolderPath -Force
+}
+$fullPath = Join-Path -Path $logFolderPath -childPath ".gitignore"
+if (!(Test-Path $fullPath -PathType Leaf)) {
+	New-Item -ItemType File -Path $fullPath
+}
+Set-Content -Path $fullPath -Value "*"
+$logFilePath = Join-Path -Path $logFolderPath $fileName
+
+function Run-StrykerForOneAssembly ($csprojPath, $testPath, $solutionPath, $outputPath) {
+    Write-Log "csprojPath: $csprojPath"
+    Write-Log ("Moving to test directory: $testPath")
+
+    Set-Location $testPath
+
+    Write-Log "Calling Stryker"
+	if ([string]::IsNullOrEmpty($commitId)) {
+		dotnet stryker --project "$csprojPath" --reporter "json" --reporter "progress" --log-to-file --config-file "$strykerConfigFile"
+	}
+	else {
+		dotnet stryker --project "$csprojPath" --reporter "json" --reporter "progress" --log-to-file --since:"$commitId" --config-file "$strykerConfigFile"
+	}
+
+    if( -not $? ){
+        Write-Log "Error in running Stryker, exiting the script"
+        # write error output to Azure DevOps
+        Write-Log "##vso[task.complete result=Failed;]Error"
+        exit;
+    }
+
+    $searchPath = Split-Path -Path $testPath
+    Write-Log "Searching for json files in this path: $searchPath"
+    # find all json result files and use the most recent one
+    $files = Get-ChildItem -Path "$searchPath"  -Filter "*.json" -Recurse -ErrorAction SilentlyContinue -Force
+    $file = $files | Sort-Object {$_.LastWriteTime} | Select-Object -last 1
+    
+    # get the name and the timestamp of the file
+    $orgReportFilePath=$file.FullName
+    $splitted = $splitted = $orgReportFilePath.split("\")
+    $dateTimeStamp = $splitted[$splitted.Length - 3]
+    $fileName =  $splitted[$splitted.Length - 1]
+	$item = Get-Item -Path $csprojPath
+    Write-Log "Last file filename: $orgReportFilePath has timestamp: $dateTimeStamp"
+
+    # create a new filename to use in the output
+    $newFileName = "$outputPath" + $dateTimeStamp + $item.Name + "_"+ $fileName
+    Write-Log "Copy the report file to '$newFileName'"
+    # write the new file out to the report directory
+    Copy-Item "$orgReportFilePath" "$newFileName"
+}
+
+function Write-Log($text) {
+	Write-Host $text
+	$text | Out-File -FilePath $logFilePath -Append
+}
+
+try {
+	Run-StrykerForOneAssembly $csprojPath $testPath $solutionPath $outputPath -ErrorAction Stop
+}
+catch {
+	Write-Log $Error[0]
+}

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,0 +1,13 @@
+{
+  "stryker-config": {
+    "mutate": [
+      "!**/program.cs",
+      "!**/ServiceRegistration/*.cs",
+      "!**/*Controller.cs",
+      "!**/ServiceRegistrar/*.cs",
+      "!**/Interface*/*.cs",
+      "!**/Swashbuckle/*.cs",
+      "!Swagger*.cs"
+    ]
+  }
+}


### PR DESCRIPTION
Have made changes to include following capability

1. For a given commitId, get the project pair (functional project & test project) in which changes are done. if no commit id is available, then entire project pair in the solution will be considered for execution
2. Run stryker in paralllel using start-job cmdlet and track for the completion
3. Combine json report had issue for latest stryker version and fixed